### PR TITLE
Install OS-level Ansible dependencies

### DIFF
--- a/ansible-playbook.sh
+++ b/ansible-playbook.sh
@@ -41,5 +41,5 @@ echo "Visit:"
 echo "http://node1/"
 echo "http://node2/"
 echo " "
-echo "https//master/ - for StackStorm control panel"
+echo "https://master/ - for StackStorm control panel"
 exit 0

--- a/ansible.sh
+++ b/ansible.sh
@@ -1,5 +1,8 @@
 set -e
 
+echo "####################### Install st2 Ansible pack OS dependencies ############################"
+apt-get -y install gcc libkrb5-dev
+
 echo "############################## Install st2 Ansible pack #####################################"
 # custom repo
 #st2 run packs.install packs=ansible repo_url=https://github.com/armab/st2contrib.git branch=feature/ansible


### PR DESCRIPTION
Fixes #4 which had missing OS-level Ansible requirements (https://github.com/stackstorm-exchange/stackstorm-ansible#requirements)

`sudo apt-get install gcc libkrb5-dev` should fix it.